### PR TITLE
Fixing some rules; conflicts and misc

### DIFF
--- a/src/rules/Xcompose.txt
+++ b/src/rules/Xcompose.txt
@@ -198,7 +198,7 @@ include "%L"
 <Multi_key> <slash> <n> <i>		: "∌"	U220C		# DOES NOT CONTAIN AS MEMBER
 # <exclam><n><i> would conflict, with <exclam> <n> for N WITH UNDERDOT, etc.
 <Multi_key> <U220B> <slash>		: "∌"	U220C		# DOES NOT CONTAIN AS MEMBER
-<Multi_key> <asciitilde> <equal>			: "≅"	U2245		# APPROXIMATELY EQUAL TO (It actually means "congruent"!)
+<Multi_key> <asciitilde> <equal>			: "≅"	U2245		# APPROXIMATELY EQUAL TO (It actually means 'congruent'!)
 <Multi_key> <equal> <question>		: "≟"	U225f		# QUESTIONED EQUAL TO
 <Multi_key> <equal> <d> <e> <f>		: "≝"	U225D		# EQUAL TO BY DEFINITION
 <Multi_key> <equal> <equal>		: "≡"	U2261		# IDENTICAL TO
@@ -534,8 +534,8 @@ include "%L"
 <Multi_key> <o> <3>			: "߷"	U07F7		# NKO SYMBOL GBAKURUNEN
 <Multi_key> <exclam> <question>         : "‽"   U203D           # INTERROBANG
 <Multi_key> <question> <exclam>         : "‽"   U203D           # INTERROBANG (in case you can’t remember the order)
-<Multi_key> <questiondown> <exclamdown>	: "⸘"	U2E18		# INVERTED INTERROBANG (if you have a ¡ key.  Otherwise...? "?i" maybe?
-<Multi_key> <exclamdown> <questiondown>	: "⸘"	U2E18		# INVERTED INTERROBANG (if you have a ¡ key.  Otherwise...? "?i" maybe?
+<Multi_key> <questiondown> <exclamdown>	: "⸘"	U2E18		# INVERTED INTERROBANG (if you have a ¡ key.  Otherwise...? '?i' maybe?)
+<Multi_key> <exclamdown> <questiondown>	: "⸘"	U2E18		# INVERTED INTERROBANG (if you have a ¡ key.  Otherwise...? '?i' maybe?)
 <Multi_key> <question> <less>	      : "⸮"	  U2E2E		# REVERSED QUESTION MARK
 <Multi_key> <question> <BackSpace>      : "⸮"	  U2E2E		# REVERSED QUESTION MARK
 <Multi_key> <question> <ampersand> <question>	  : "⁇"	 U2047	# DOUBLE QUESTION MARK

--- a/src/rules/Xcompose.txt
+++ b/src/rules/Xcompose.txt
@@ -38,7 +38,7 @@ include "%L"
 <Multi_key> <apostrophe> <space>	: "’"	U2019		# RIGHT SINGLE QUOTATION MARK
 <Multi_key> <apostrophe> <apostrophe>	: "”"	U201D		# RIGHT DOUBLE QUOTATION MARK
 <Multi_key> <grave> <space>		: "‘"	U2018		# LEFT SINGLE QUOTATION MARK
-<Multi_key> <grave> <grave>		: "“"	U201C		# LEFT DOUBLE QUOTATION MARK
+<Multi_key> <2> <grave> <space>		: "“"	U201C		# LEFT DOUBLE QUOTATION MARK
 <Multi_key> <6> <apostrophe>		: "‘"	U2018		# LEFT SINGLE QUOTATION MARK (high 6)
 <Multi_key> <6> <quotedbl>		: "“"	U201C		# LEFT DOUBLE QUOTATION MARK (66)
 <Multi_key> <9> <apostrophe>		: "’"	U2019		# RIGHT SINGLE QUOTATION MARK (high 9)
@@ -79,7 +79,7 @@ include "%L"
 <Multi_key> <less> <minus> <greater>	: "↔"	U2194           # LEFT RIGHT ARROW (kragen's)
 
 <Multi_key> <Left> <Left>		: "←"	leftarrow	# LEFTWARDS ARROW
-<Multi_key> <Up> <Up>			: "↑"	uparrow		# UPWARDS ARROW
+<Multi_key> <Up> <Up> <Up>		: "↑"	uparrow		# UPWARDS ARROW
 <Multi_key> <Right> <Right>		: "→"	rightarrow	# RIGHTWARDS ARROW
 <Multi_key> <Down> <Down>		: "↓"	downarrow	# DOWNWARDS ARROW
 <Multi_key> <Left> <Right>		: "↔"	U2194           # LEFT RIGHT ARROW (kragen's)
@@ -432,7 +432,7 @@ include "%L"
 # Sorry, couldn't think of better ones for these.  Might want .s for SAN.
 <Multi_key> <asterisk> <question>      : "Ϛ"	U03DA	# GREEK LETTER STIGMA
 <Multi_key> <asterisk> <slash>	       : "ϛ"	U03DB	# GREEK SMALL LETTER STIGMA
-<Multi_key> <asterisk> <apostrophe>    : "ʹ"	U02B9	# MODIFIER LETTER PRIME, canonically equivalent to U0374 GREEK NUMERAL SIGN
+<Multi_key> <asterisk> <apostrophe> <space>   : "ʹ"	U02B9	# MODIFIER LETTER PRIME, canonically equivalent to U0374 GREEK NUMERAL SIGN
 # While we're at it...
 <Multi_key> <asterisk> <period> <apostrophe>	: "′"	U2032	# PRIME
 <Multi_key> <asterisk> <period> <quotedbl>      : "″"	U2033	# DOUBLE PRIME
@@ -805,7 +805,7 @@ include "%L"
 <Multi_key> <backslash> <period>	: "̇"	U0307	# COMBINING DOT ABOVE
 <Multi_key> <backslash> <quotedbl>	: "̈"	U0308	# COMBINING DIAERESIS
 <Multi_key> <backslash> <question>	: "̉"	U0309	# COMBINING HOOK ABOVE
-<Multi_key> <backslash> <o>		: "̊"	U030a	# COMBINING RING ABOVE
+#<Multi_key> <backslash> <o>		: "̊"	U030a	# COMBINING RING ABOVE
 # That now conflicts with the new 🙌 in the system xcompose.  Alternative:
 <Multi_key> <backslash> <0>   	       	: "̊"	U030a	# COMBINING RING ABOVE
 <Multi_key> <backslash> <backslash> <apostrophe>	: "̋"	U030b	# COMBINING DOUBLE ACUTE ACCENT -- ??

--- a/src/rules/Xorg.txt
+++ b/src/rules/Xorg.txt
@@ -65,7 +65,7 @@
 <Multi_key> <minus> <asciicircum> 	: "¯"   macron # MACRON
 <Multi_key> <asciicircum> <minus> 	: "¯"   macron # MACRON
 <Multi_key> <underscore> <underscore> 	: "¯"   macron # MACRON
-<Multi_key> <underscore> <asciicircum> 	: "¯"   macron # MACRON
+#<Multi_key> <underscore> <asciicircum>  	: "¯"   macron # MACRON
 <dead_breve> <space>             	: "˘"   breve # BREVE
 <dead_breve> <dead_breve>        	: "˘"   breve # BREVE
 <Multi_key> <space> <parenleft>		: "˘"   breve # BREVE
@@ -92,7 +92,7 @@
 
 # ASCII characters that may be difficult to access
 # on some keyboards.
-<Multi_key> <plus> <plus>        	: "#"   numbersign # NUMBER SIGN
+<Multi_key> <plus> <plus> <plus> 	: "#"   numbersign # NUMBER SIGN
 <Multi_key> <apostrophe> <space> 	: "'"   apostrophe # APOSTROPHE
 <Multi_key> <space> <apostrophe> 	: "'"   apostrophe # APOSTROPHE
 <Multi_key> <A> <T>              	: "@"   at # COMMERCIAL AT
@@ -114,7 +114,7 @@
 <Multi_key> <space> <comma>      	: "¸"   cedilla # CEDILLA
 <Multi_key> <comma> <comma> 		: "¸"   cedilla # CEDILLA
 
-<Multi_key> <parenleft> <minus>  	: "{"   braceleft # LEFT CURLY BRACKET
+#<Multi_key> <parenleft> <minus>  	: "{"   braceleft # LEFT CURLY BRACKET
 <Multi_key> <minus> <parenleft>  	: "{"   braceleft # LEFT CURLY BRACKET
 
 <Multi_key> <slash> <asciicircum> 	: "|"   bar # VERTICAL LINE
@@ -222,7 +222,7 @@
 <Multi_key> <equal> <W>          	: "₩"   U20a9 # WON SIGN
 # "₪" U20aa NEW SHEQEL SIGN
 <Multi_key> <d> <equal>          	: "₫"   U20ab # DONG SIGN
-<Multi_key> <equal> <d>          	: "₫"   U20ab # DONG SIGN
+#<Multi_key> <equal> <d>        	: "₫"   U20ab # DONG SIGN
 <Multi_key> <C> <equal>          	: "€"   EuroSign # EURO SIGN
 <Multi_key> <equal> <C>          	: "€"   EuroSign # EURO SIGN
 <Multi_key> <c> <equal>          	: "€"   EuroSign # EURO SIGN
@@ -874,7 +874,7 @@
 <Multi_key> <C> <period> 		: "Ċ"   U010A # LATIN CAPITAL LETTER C WITH DOT ABOVE
 <dead_abovedot> <c>              	: "ċ"   U010B # LATIN SMALL LETTER C WITH DOT ABOVE
 <Multi_key> <period> <c>         	: "ċ"   U010B # LATIN SMALL LETTER C WITH DOT ABOVE
-<Multi_key> <c> <period> 		: "ċ"   U010B # LATIN SMALL LETTER C WITH DOT ABOVE
+#<Multi_key> <c> <period> 	   : "ċ"   U010B # LATIN SMALL LETTER C WITH DOT ABOVE
 <dead_caron> <C>                 	: "Č"   U010C # LATIN CAPITAL LETTER C WITH CARON
 <Multi_key> <c> <C>              	: "Č"   U010C # LATIN CAPITAL LETTER C WITH CARON
 <Multi_key> <less> <C> 			: "Č"   U010C # LATIN CAPITAL LETTER C WITH CARON
@@ -937,7 +937,7 @@
 <Multi_key> <E> <less> 			: "Ě"   U011A # LATIN CAPITAL LETTER E WITH CARON
 <dead_caron> <e>                 	: "ě"   U011B # LATIN SMALL LETTER E WITH CARON
 <Multi_key> <c> <e>              	: "ě"   U011B # LATIN SMALL LETTER E WITH CARON
-<Multi_key> <less> <e> 			: "ě"   U011B # LATIN SMALL LETTER E WITH CARON
+#<Multi_key> <less> <e> 		: "ě"   U011B # LATIN SMALL LETTER E WITH CARON
 <Multi_key> <e> <less> 			: "ě"   U011B # LATIN SMALL LETTER E WITH CARON
 <dead_circumflex> <G>            	: "Ĝ"   U011C # LATIN CAPITAL LETTER G WITH CIRCUMFLEX
 <Multi_key> <asciicircum> <G>    	: "Ĝ"   U011C # LATIN CAPITAL LETTER G WITH CIRCUMFLEX
@@ -1102,7 +1102,7 @@
 <Multi_key> <underscore> <o>     	: "ō"   U014D # LATIN SMALL LETTER O WITH MACRON
 <Multi_key> <o> <underscore>     	: "ō"   U014D # LATIN SMALL LETTER O WITH MACRON
 <Multi_key> <minus> <o>         	: "ō"   U014D # LATIN SMALL LETTER O WITH MACRON
-<Multi_key> <o> <minus>         	: "ō"   U014D # LATIN SMALL LETTER O WITH MACRON
+#<Multi_key> <o> <minus>        	: "ō"   U014D # LATIN SMALL LETTER O WITH MACRON
 <dead_breve> <O>                 	: "Ŏ"   U014E # LATIN CAPITAL LETTER O WITH BREVE
 <Multi_key> <U> <O>              	: "Ŏ"   U014E # LATIN CAPITAL LETTER O WITH BREVE
 <Multi_key> <b> <O>              	: "Ŏ"   U014E # LATIN CAPITAL LETTER O WITH BREVE
@@ -2743,7 +2743,7 @@
 <dead_belowdot> <I>              	: "Ị"   U1ECA # LATIN CAPITAL LETTER I WITH DOT BELOW
 <Multi_key> <exclam> <I>         	: "Ị"   U1ECA # LATIN CAPITAL LETTER I WITH DOT BELOW
 <dead_belowdot> <i>              	: "ị"   U1ECB # LATIN SMALL LETTER I WITH DOT BELOW
-<Multi_key> <exclam> <i>         	: "ị"   U1ECB # LATIN SMALL LETTER I WITH DOT BELOW
+#<Multi_key> <exclam> <i>         : "ị"   U1ECB # LATIN SMALL LETTER I WITH DOT BELOW
 <dead_belowdot> <O>              	: "Ọ"   U1ECC # LATIN CAPITAL LETTER O WITH DOT BELOW
 <Multi_key> <exclam> <O>         	: "Ọ"   U1ECC # LATIN CAPITAL LETTER O WITH DOT BELOW
 <dead_belowdot> <o>              	: "ọ"   U1ECD # LATIN SMALL LETTER O WITH DOT BELOW
@@ -4555,7 +4555,7 @@
 <Multi_key> <KP_Divide> <rightarrow> 	: "↛"   U219B # RIGHTWARDS ARROW WITH STROKE
 <Multi_key> <slash> <U2194>  	: "↮"   U21AE # LEFT RIGHT ARROW WITH STROKE
 <Multi_key> <KP_Divide> <U2194> 	: "↮"   U21AE # LEFT RIGHT ARROW WITH STROKE
-<Multi_key> <less> <minus> 	: "←" U2190 # LEFTWARDS ARROW
+<Multi_key> <less> <minus> <minus> 	: "←" U2190 # LEFTWARDS ARROW
 <Multi_key> <minus> <greater> 	: "→" U2192 # RIGHTWARDS ARROW
 <Multi_key> <U2203> <U0338> 	: "∄"   U2204 # THERE DOES NOT EXIST
 <Multi_key> <braceleft> <braceright>	: "∅"   U2205 # EMPTY SET


### PR DESCRIPTION
- Fixes some conflicts
- Adds closing parentheses where missing
- Changes " to ' in comments to fix when trying to do multikey + =~ results in

≅"	U245	# APROXIMATELY EQUAL TO (It actualy means "congruent

instead of ≅