### PR TITLE
Fix the launch if another user session is already running

### DIFF
--- a/src/installer-helper.cpp
+++ b/src/installer-helper.cpp
@@ -149,6 +149,7 @@ void __cdecl fix_file(wchar_t const *path)
 
     // Fix some additional task settings
     fix_tag(buf, L"RunLevel", L"HighestAvailable");
+    fix_tag(buf, L"MultipleInstancesPolicy", L"Parallel");
     fix_tag(buf, L"DisallowStartIfOnBatteries", L"false");
     fix_tag(buf, L"StopIfGoingOnBatteries", L"false");
     fix_tag(buf, L"StopOnIdleEnd", L"false");


### PR DESCRIPTION
"MultipleInstancesPolicy" is set to "IgnoreNew" by default when creating a task.
Therefore, only one user session could get the WinCompose systray icon at once.
Set this parameter to "Parallel" when installing WinCompose, so that all
simultaneous user sessions can get WinCompose.

Signed-off-by: Benoît Thébaudeau <benoit.thebaudeau.dev@gmail.com>