### PR TITLE
Allow copying of sequences using Ctrl+C in the sequences window

### DIFF
--- a/src/ui/SequenceWindow.xaml
+++ b/src/ui/SequenceWindow.xaml
@@ -26,6 +26,8 @@
     <Window.CommandBindings>
         <CommandBinding Command="ApplicationCommands.Close"
                         Executed="OnCloseCommandExecuted"/>
+        <CommandBinding Command="ApplicationCommands.Copy"
+                        Executed="OnCopyCommandExecuted"/>
     </Window.CommandBindings>
 
     <Window.InputBindings>
@@ -85,7 +87,7 @@
 
         <ContextMenu x:Key="ContextMenu">
             <MenuItem Header="{x:Static i18n:Text.CopyToClipboard}" Icon="{StaticResource CopyEmoji}"
-                      Click="CopyToClipboard_Click"/>
+                      Command="ApplicationCommands.Copy"/>
             <MenuItem Header="{x:Static i18n:Text.AddToFavorites}" Icon="{StaticResource FavoriteEmoji}"
                       Click="ToggleFavorite_Click" Visibility="{Binding AddToFavoritesVisibility}"/>
             <MenuItem Header="{x:Static i18n:Text.RemoveFromFavorites}" Icon="{StaticResource UnfavoriteEmoji}"

--- a/src/ui/SequenceWindow.xaml.cs
+++ b/src/ui/SequenceWindow.xaml.cs
@@ -61,11 +61,15 @@ namespace WinCompose
                 Hide();
         }
 
+        private void OnCopyCommandExecuted(object sender, ExecutedRoutedEventArgs e)
+        {
+            var seq_view = (ListBox.SelectedItem as SequenceViewModel)?.Result;
+            if(seq_view != null)
+                Clipboard.SetText(seq_view);
+        }
+
         private void ClearSearch_Click(object sender, RoutedEventArgs e)
             => m_view_model.SearchText = "";
-
-        private void CopyToClipboard_Click(object sender, RoutedEventArgs e)
-            => Clipboard.SetText((ListBox.SelectedItem as SequenceViewModel)?.Result);
 
         private void EditUserDefinedSequences_Click(object sender, RoutedEventArgs e)
             => Settings.EditCustomRulesFile();


### PR DESCRIPTION
Add a command binding to the sequences window in order to simplify copying a sequence to the clipboard using only the keyboard. Using a command binding also automatically adds the shortcut to the context menu.