### PR TITLE
Update window content when reloading user-defined sequences

### DIFF
--- a/src/ui/SequenceWindow.xaml.cs
+++ b/src/ui/SequenceWindow.xaml.cs
@@ -75,7 +75,14 @@ namespace WinCompose
             => Settings.EditCustomRulesFile();
 
         private void ReloadUserDefinedSequences_Click(object sender, RoutedEventArgs e)
-            => Settings.LoadSequences();
+        {
+            Settings.LoadSequences();
+            // Create a new view model to sync the sequence list UI with the
+            // active sequences. Preserve the search text while doing so.
+            var search_text = m_view_model.SearchText;
+            DataContext = new RootViewModel();
+            m_view_model.SearchText = search_text;
+        }
 
         private void ToggleFavorite_Click(object sender, RoutedEventArgs e)
             => (ListBox.SelectedItem as SequenceViewModel)?.ToggleFavorite();


### PR DESCRIPTION
This is related to the bug I mentioned in https://github.com/samhocevar/wincompose/issues/332. There may be a more elegant way to fix this that I couldn't think of but this seems relatively clean and it worked great during my testing.

The sequence list is loaded into the RootViewModel on construction, so
the sequences in the Settings don't stay in sync after that. When
reloading the user-defined sequences we therefore need to create a new
RootViewModel for the UI to reflect the active list of sequences.

Steps to reproduce the problem fixed by this commit:
1. Open the Sequences window
2. Click the Edit button to edit user-defined sequences
3. Add a new sequence
4. Save and exist the editor
5. Click the Reload button
6. Try using the new sequence. It should work.
7. Search for the new sequence. It doesn't show up.