### PR TITLE
Install Task Scheduler only when not running in detached mode

### DIFF
--- a/src/wincompose/Program.cs
+++ b/src/wincompose/Program.cs
@@ -50,6 +50,7 @@ namespace WinCompose
 
             bool from_task = args.Contains("-fromtask");
             bool from_startup = args.Contains("-fromstartup");
+            bool detached = args.Contains("-detached");
 
             // If run from Task Scheduler or from startup but autolaunch is
             // disabled, exit early.
@@ -82,7 +83,9 @@ namespace WinCompose
             // Try to install the Task Scheduler entry. The best time for this is
             // just after installation, when the installer launches us with elevated
             // privileges.
-            if (!from_task && Settings.AutoLaunch.Value)
+			// If we have started from task and are now detached, do not try to
+			// create task again. It already exists and most likely will fail.
+            if (!from_task && Settings.AutoLaunch.Value && !detached)
             {
                 var ret = TaskScheduler.InstallTask("WinCompose", $"\"{Utils.ExecutableName}\" -fromtask",
                                                     elevated: true, author: "Sam Hocevar");


### PR DESCRIPTION
When using Windows 11, installing Windows Terminal and configuring Windows Terminal as the default application, the startup with the task scheduler leads
1) process being started and restarting itself with "-detached"
2) detached process being started and tries to install the Task-Scheduler Entry again.

For various reasons this second step might fail (e.g. Access Denied) and with the default configuration of Windows Terminal the command prompt window will stay open.

This merge request will not try to install the Task-Scheduler Entry when being started in detached mode, and hence avoids this unnecessary and error-prone step,