### PR TITLE
Update the README's discussion of early exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,9 @@ with sequences.
 WinCompose supports rules of more than 2 characters such as <kbd>⎄ Compose</kbd>
 <kbd>(</kbd> <kbd>3</kbd> <kbd>)</kbd> for **③**.
 
-WinCompose supports early exits. For instance, <kbd>⎄ Compose</kbd> <kbd>q</kbd> will
-immediately type **q** because there is currently no rule starting with <kbd>q</kbd>.
+WinCompose supports early exits. For instance, <kbd>⎄ Compose</kbd> <kbd>Q</kbd> will
+immediately type **Q** because there is currently no rule starting with the capital
+letter <kbd>Q</kbd>.
 
 As of now, WinCompose is almost fully translated to Afrikaans, Belarusian, Catalan, Chinese,
 Czech, Dutch, Estonian, French, German, Greek, Italian, Japanese, Lithuanian, Norwegian, Polish,


### PR DESCRIPTION
The README stated that <kbd>⎄ Compose</kbd> <kbd>q</kbd> led to an early exit.  As @MaaaxiKing has [pointed out](https://github.com/samhocevar/wincompose/pull/456#issue-1134556603), this statement is now outdated.  The statement is no longer correct.

In truth, <kbd>⎄ Compose</kbd> <kbd>q</kbd> no longer leads to an early exit.  But <kbd>⎄ Compose</kbd> <kbd>Q</kbd> still does.

This commit updates the README to use a capital <kbd>Q</kbd> instead of a lowercase <kbd>q</kbd>.