### PR TITLE
fix bug where capslock capitalizes micro sign µ

### DIFF
--- a/src/wincompose/Composer.cs
+++ b/src/wincompose/Composer.cs
@@ -165,7 +165,7 @@ static class Composer
         {
             Key alt_key = KeyboardLayout.VkToKey(vk, sc, flags, has_shift, has_altgr, false);
 
-            if (alt_key.IsPrintable && alt_key.PrintableResult[0] > 0x7f)
+            if (alt_key.IsPrintable && alt_key.PrintableResult[0] > 0xbf)
             {
                 string str_upper = alt_key.PrintableResult.ToUpper();
                 string str_lower = alt_key.PrintableResult.ToLower();


### PR DESCRIPTION
By starting the range at U+00C0 onward, the capslock hack doesn't need to care about C1 controls or Latin 1 punctuation characters, including an issue where it erroneously capitalizes the Micro sign to the real capital Greek Mu. #475