### PR TITLE
Fix capslock hack capitalizing Micro sign µ to real Greek Mu

### DIFF
--- a/src/wincompose/Composer.cs
+++ b/src/wincompose/Composer.cs
@@ -165,7 +165,7 @@ static class Composer
         {
             Key alt_key = KeyboardLayout.VkToKey(vk, sc, flags, has_shift, has_altgr, false);
 
-            if (alt_key.IsPrintable && alt_key.PrintableResult[0] > 0x7f)
+            if (alt_key.IsPrintable && alt_key.PrintableResult[0] > 0xbf)
             {
                 string str_upper = alt_key.PrintableResult.ToUpper();
                 string str_lower = alt_key.PrintableResult.ToLower();


### PR DESCRIPTION
Without this fix, it is impossible to reliably use the micro sign in a sequence with capslock on and capslock hack enabled, even when matching case insensitive input is also enabled, as the lowercase of the real capital Greek Mu becomes the real lowercase Greek mu, which is a different codepoint and also another named keysym.<br>
This has been tested and confirmed to fix #475