### PR TITLE
Update Unicode block knowledge via unicodetools git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -41,3 +41,6 @@
 	url = ../../jrsoftware/issrc.git
 	branch = main
 	update = merge
+[submodule "src/3rdparty/unicodetools"]
+	path = src/3rdparty/unicodetools
+	url = https://github.com/unicode-org/unicodetools

--- a/src/wincompose/sequences/Category.cs
+++ b/src/wincompose/sequences/Category.cs
@@ -96,17 +96,19 @@ namespace WinCompose
         {
             var list = new List<CodepointCategory>();
 
-            const BindingFlags flags = BindingFlags.Static | BindingFlags.Public;
-            Regex r = new Regex(@"^U([a-fA-F0-9]*)_U([a-fA-F0-9]*)$");
-            foreach (var property in typeof(unicode.Block).GetProperties(flags))
+            using (var reader = new GZipResourceStream("Blocks.txt.gz"))
             {
-                Match m = r.Match(property.Name);
-                if (m.Success)
+                Regex r = new Regex(@"^([a-fA-F0-9]*)\.\.([a-fA-F0-9]*); ([A-Za-z0-9 \-]*)$");
+                for (string l = reader.ReadLine(); l != null; l = reader.ReadLine())
                 {
-                    var name = (string)property.GetValue(null, null);
-                    var start = Convert.ToInt32(m.Groups[1].Value, 16);
-                    var end = Convert.ToInt32(m.Groups[2].Value, 16);
-                    list.Add(new CodepointCategory() { Name = name, RangeStart = start, RangeEnd = end });
+                    Match m = r.Match(l);
+                    if (m.Success)
+                    {
+                        var start = Convert.ToInt32(m.Groups[1].Value, 16);
+                        var end = Convert.ToInt32(m.Groups[2].Value, 16);
+                        var name = (string)m.Groups[3].Value;
+                        list.Add(new CodepointCategory() { Name = name, RangeStart = start, RangeEnd = end });
+                    }
                 }
             }
 

--- a/src/wincompose/wincompose.csproj
+++ b/src/wincompose/wincompose.csproj
@@ -39,21 +39,25 @@
           Inputs="..\3rdparty\xorgproto\include\X11\keysymdef.h&#xD;&#xA;
                   ..\3rdparty\libx11\nls\en_US.UTF-8\Compose.pre&#xD;&#xA;
                   ..\3rdparty\xcompose\dotXCompose&#xD;&#xA;
-                  ..\3rdparty\unicode-emoji\emoji-test.txt"
+                  ..\3rdparty\unicode-emoji\emoji-test.txt&#xD;&#xA;
+				  ..\3rdparty\unicodetools\unicodetools\data\ucd\15.0.0\Blocks.txt"
           Outputs="$(OutputPath)\keysymdef.h.gz&#xD;&#xA;
                    $(OutputPath)\xorg.rules.gz&#xD;&#xA;
                    $(OutputPath)\xcompose.rules.gz&#xD;&#xA;
-                   $(OutputPath)\emoji-test.txt.gz">
+                   $(OutputPath)\emoji-test.txt.gz&#xD;&#xA;
+				   $(OutputPath)\Blocks.txt.gz">
     <GZipTask InputFile="..\3rdparty\xorgproto\include\X11\keysymdef.h" OutputFile="$(OutputPath)\keysymdef.h.gz" />
     <GZipTask InputFile="..\3rdparty\libx11\nls\en_US.UTF-8\Compose.pre" OutputFile="$(OutputPath)\xorg.rules.gz" />
     <GZipTask InputFile="..\3rdparty\xcompose\dotXCompose" OutputFile="$(OutputPath)\xcompose.rules.gz" />
     <GZipTask InputFile="..\3rdparty\unicode-emoji\emoji-test.txt" OutputFile="$(OutputPath)\emoji-test.txt.gz" />
+	<GZipTask InputFile="..\3rdparty\unicodetools\unicodetools\data\ucd\15.0.0\Blocks.txt" OutputFile="$(OutputPath)\Blocks.txt.gz"/>
   </Target>
   <ItemGroup>
     <Item Include="..\3rdparty\xorgproto\include\X11\keysymdef.h" />
     <Item Include="..\3rdparty\libx11\nls\en_US.UTF-8\Compose.pre" />
     <Item Include="..\3rdparty\xcompose\dotXCompose" />
     <Item Include="..\3rdparty\unicode-emoji\emoji-test.txt" />
+	<Item Include="..\3rdparty\unicodetools\unicodetools\data\ucd\15.0.0\Blocks.txt" />
   </ItemGroup>
 
   <ItemGroup>
@@ -86,6 +90,10 @@
       <Visible>false</Visible>
       <LogicalName>emoji-test.txt.gz</LogicalName>
     </EmbeddedResource>
+	<EmbeddedResource Include="$(OutputPath)\Blocks.txt.gz">
+	  <Visible>false</Visible>
+	  <LogicalName>Blocks.txt.gz</LogicalName>
+	</EmbeddedResource>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Microsoft is clearly disinterested in keeping Windows' internal Unicode information up to date.<br>According to [this documentation article on their website](https://learn.microsoft.com/en-us/dotnet/core/extensions/globalization-icu), newer versions of the dotnet standard don't even use it anymore, opting instead to pull straight from the ICU. This is a workaround.
Unicode character properties are a whole other issue, but this patch's inclusion of unicodetools makes it possible.<br>
Proof that this patch does indeed work:<br>
![screenshot of sequences window showing Latin Extended-F superscript sequences](https://user-images.githubusercontent.com/37010132/214118234-0ab68f3c-2363-4f5d-92c2-8ebbb32624a9.png)
