### PR TITLE
Remove requirement that allows only certain keys as compose keys

### DIFF
--- a/src/wincompose/settings/Settings.cs
+++ b/src/wincompose/settings/Settings.cs
@@ -121,7 +121,6 @@ namespace WinCompose
         [EntryLocation("advanced", "ignore_regex")]
         public static SettingsEntry<string> IgnoreRegex { get; } = new SettingsEntry<string>("");
 
-        public static IEnumerable<Key> ValidComposeKeys => m_valid_compose_keys;
         public static Dictionary<string, string> ValidLanguages => m_valid_languages;
 
         public static IList<Key> ValidLedKeys { get; } = new List<Key>
@@ -162,9 +161,7 @@ namespace WinCompose
                 // but re-add it if there are no valid keys at all.
                 foreach (Key k in ComposeKeys.Value)
                 {
-                    bool is_valid = (k.VirtualKey >= VK.F1 && k.VirtualKey <= VK.F24)
-                                     || m_valid_compose_keys.Contains(k);
-                    if (is_valid && k.VirtualKey != VK.DISABLED && !compose_keys.Contains(k))
+                    if (k.VirtualKey != VK.DISABLED && !compose_keys.Contains(k))
                         compose_keys.Add(k);
                 }
 
@@ -358,32 +355,6 @@ namespace WinCompose
 
         // Tree of all known sequences
         private static SequenceTree m_sequences = new SequenceTree();
-
-        // FIXME: couldn't we accept any compose key?
-        private static readonly KeySequence m_valid_compose_keys = new KeySequence
-        {
-           new Key(VK.DISABLED),
-           new Key(VK.LMENU),
-           new Key(VK.RMENU),
-           new Key(VK.LCONTROL),
-           new Key(VK.RCONTROL),
-           new Key(VK.LWIN),
-           new Key(VK.RWIN),
-           new Key(VK.CAPITAL),
-           new Key(VK.NUMLOCK),
-           new Key(VK.PAUSE),
-           new Key(VK.APPS),
-           new Key(VK.ESCAPE),
-           new Key(VK.CONVERT),
-           new Key(VK.NONCONVERT),
-           new Key(VK.INSERT),
-           new Key(VK.SNAPSHOT),
-           new Key(VK.SCROLL),
-           new Key(VK.TAB),
-           new Key(VK.HOME),
-           new Key(VK.END),
-           new Key("`"),
-        };
 
         private static readonly Key m_default_compose_key = new Key(VK.RMENU);
 

--- a/src/wincompose/ui/KeySelector.xaml.cs
+++ b/src/wincompose/ui/KeySelector.xaml.cs
@@ -36,8 +36,8 @@ namespace WinCompose
 
         private void KeyCaptured(Key k)
         {
-            // Only accept non-printing keys for now, except Escape.
-            if (k.VirtualKey != VK.ESCAPE && !k.IsPrintable)
+            // Don't accept Escape as compose key.
+            if (k.VirtualKey != VK.ESCAPE)
             {
                 Key = k;
                 // Close window from the right thread. Performance is not a


### PR DESCRIPTION
Remove hard-coded requirements that allows only certain keys to be set as compose keys. Any key can now be set as the compose key, allowing for greater user flexibility in choosing an appropriate compose key.

I've tested the code locally by compiling an installer and installing it (on windows only). I couldn't find any issues with it, so no further tweaks seemed necessary. Potential useful addition would be to give a warning when setting a letter key (e.g. 'A') as a compose key, as it makes little sense and blocks the use of a necessary key. However, it's an obvious enough problem that the user can simply change the compose key once they realise the problem.